### PR TITLE
Change the external_id field to be an enum instead of a regular String

### DIFF
--- a/src/jobs/da_job/mod.rs
+++ b/src/jobs/da_job/mod.rs
@@ -20,7 +20,7 @@ impl Job for DaJob {
             internal_id,
             job_type: JobType::DataSubmission,
             status: JobStatus::Created,
-            external_id: String::new(),
+            external_id: String::new().into(),
             metadata: HashMap::new(),
             version: 0,
         })
@@ -49,7 +49,7 @@ impl Job for DaJob {
     }
 
     async fn verify_job(&self, config: &Config, job: &JobItem) -> Result<JobVerificationStatus> {
-        Ok(config.da_client().verify_inclusion(job.external_id.as_str()).await?)
+        Ok(config.da_client().verify_inclusion(job.external_id.unwrap_string()?).await?)
     }
 
     fn max_process_attempts(&self) -> u64 {


### PR DESCRIPTION
This pull request changes the `external_id` field of `JobData` to be a custom `ExternalId` instead of a `String`.

This allows job implementations to choose whichever format best suits their needs instead of forcing them into a string.

The `ExternalId` type is defined as follows:

```rust
enum ExternalId {
    String(Box<str>),
    Number(usize),
}
```

# Failed Attempts

The original idea was to use a `Box<dyn Any>` instead of an enum, but implementing `Serialize` and `Deserialize` for those is [kinda tricky](https://github.com/dtolnay/erased-serde) and I think the added ]dependencies and complexity overhead are not worth the effort.

Instead of a trait object, I opted for a simple enum. Variants can be added as needed.