### PR TITLE
Build Client inside DaConfig

### DIFF
--- a/crates/da-clients/da-client-interface/src/lib.rs
+++ b/crates/da-clients/da-client-interface/src/lib.rs
@@ -33,5 +33,5 @@ pub trait DaClient: Send + Sync {
 pub trait DaConfig<T> {
     /// Should create a new instance of the DaConfig from the environment variables
     fn new_from_env() -> Self;
-    async fn build_da_client(&self) -> T;
+    async fn build_client(&self) -> T;
 }

--- a/crates/da-clients/da-client-interface/src/lib.rs
+++ b/crates/da-clients/da-client-interface/src/lib.rs
@@ -29,7 +29,9 @@ pub trait DaClient: Send + Sync {
 }
 
 /// Trait for every new DaConfig to implement
-pub trait DaConfig {
+#[async_trait]
+pub trait DaConfig<T> {
     /// Should create a new instance of the DaConfig from the environment variables
     fn new_from_env() -> Self;
+    async fn build_da_client(&self) -> T;
 }

--- a/crates/da-clients/ethereum/src/config.rs
+++ b/crates/da-clients/ethereum/src/config.rs
@@ -27,7 +27,7 @@ impl DaConfig<EthereumDaClient> for EthereumDaConfig {
             private_key: get_env_var_or_panic("PRIVATE_KEY"),
         }
     } 
-    async fn build_da_client(&self) -> EthereumDaClient{
+    async fn build_client(&self) -> EthereumDaClient{
         let client = RpcClient::new_http(Url::from_str(self.rpc_url.as_str()).expect("Failed to parse ETHEREUM_RPC_URL"));
         let provider = ProviderBuilder::<_, Ethereum>::new().on_client(client);
         let wallet: LocalWallet = env::var("PK").expect("PK must be set").parse().expect("issue while parsing");

--- a/crates/da-clients/ethereum/src/config.rs
+++ b/crates/da-clients/ethereum/src/config.rs
@@ -1,5 +1,6 @@
 use da_client_interface::DaConfig;
 use utils::env_utils::get_env_var_or_panic;
+use async_trait::async_trait;
 
 #[derive(Clone, Debug)]
 pub struct EthereumDaConfig {
@@ -8,12 +9,16 @@ pub struct EthereumDaConfig {
     pub private_key: String,
 }
 
-impl DaConfig for EthereumDaConfig {
+#[async_trait]
+impl DaConfig<String> for EthereumDaConfig {
     fn new_from_env() -> Self {
         Self {
             rpc_url: get_env_var_or_panic("ETHEREUM_RPC_URL"),
             memory_pages_contract: get_env_var_or_panic("MEMORY_PAGES_CONTRACT_ADDRESS"),
             private_key: get_env_var_or_panic("PRIVATE_KEY"),
         }
+    } 
+    async fn build_da_client(&self) -> String{
+        "Create Ethereum Client here".to_string()
     }
 }

--- a/crates/da-clients/ethereum/src/config.rs
+++ b/crates/da-clients/ethereum/src/config.rs
@@ -1,13 +1,13 @@
-use std::{env, path::Path};
 use std::str::FromStr;
+use std::{env, path::Path};
 
+use alloy::signers::wallet::LocalWallet;
 use alloy::{network::Ethereum, providers::ProviderBuilder, rpc::client::RpcClient};
+use async_trait::async_trait;
 use c_kzg::KzgSettings;
 use da_client_interface::DaConfig;
 use url::Url;
 use utils::env_utils::get_env_var_or_panic;
-use async_trait::async_trait;
-use alloy::signers::wallet::LocalWallet;
 
 use crate::EthereumDaClient;
 
@@ -26,9 +26,10 @@ impl DaConfig<EthereumDaClient> for EthereumDaConfig {
             memory_pages_contract: get_env_var_or_panic("MEMORY_PAGES_CONTRACT_ADDRESS"),
             private_key: get_env_var_or_panic("PRIVATE_KEY"),
         }
-    } 
-    async fn build_client(&self) -> EthereumDaClient{
-        let client = RpcClient::new_http(Url::from_str(self.rpc_url.as_str()).expect("Failed to parse ETHEREUM_RPC_URL"));
+    }
+    async fn build_client(&self) -> EthereumDaClient {
+        let client =
+            RpcClient::new_http(Url::from_str(self.rpc_url.as_str()).expect("Failed to parse ETHEREUM_RPC_URL"));
         let provider = ProviderBuilder::<_, Ethereum>::new().on_client(client);
         let wallet: LocalWallet = env::var("PK").expect("PK must be set").parse().expect("issue while parsing");
         // let wallet: LocalWallet = config.private_key.as_str().parse();

--- a/crates/da-clients/ethereum/src/lib.rs
+++ b/crates/da-clients/ethereum/src/lib.rs
@@ -17,7 +17,6 @@ use c_kzg::{Blob, KzgCommitment, KzgProof, KzgSettings};
 use color_eyre::Result;
 use da_client_interface::{DaClient, DaVerificationStatus};
 use dotenv::dotenv;
-use std::path::Path;
 use mockall::automock;
 use mockall::predicate::*;
 use reqwest::Client;
@@ -133,6 +132,7 @@ async fn prepare_sidecar(
 mod tests {
     use std::fs::File;
     use std::io::{self, BufRead};
+    use std::path::Path;
 
     use super::*;
 

--- a/crates/da-clients/ethereum/src/lib.rs
+++ b/crates/da-clients/ethereum/src/lib.rs
@@ -109,19 +109,6 @@ impl DaClient for EthereumDaClient {
     }
 }
 
-impl From<EthereumDaConfig> for EthereumDaClient {
-    fn from(config: EthereumDaConfig) -> Self {
-        let client =
-            RpcClient::new_http(Url::from_str(config.rpc_url.as_str()).expect("Failed to parse ETHEREUM_RPC_URL"));
-        let provider = ProviderBuilder::<_, Ethereum>::new().on_client(client);
-        let wallet: LocalWallet = env::var("PK").expect("PK must be set").parse().expect("issue while parsing");
-        // let wallet: LocalWallet = config.private_key.as_str().parse();
-        let trusted_setup = KzgSettings::load_trusted_setup_file(Path::new("./trusted_setup.txt"))
-            .expect("issue while loading the trusted setup");
-        EthereumDaClient { provider, wallet, trusted_setup }
-    }
-}
-
 async fn prepare_sidecar(
     state_diff: &[Vec<u8>],
     trusted_setup: &KzgSettings,

--- a/crates/da-clients/ethereum/src/lib.rs
+++ b/crates/da-clients/ethereum/src/lib.rs
@@ -1,8 +1,5 @@
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
-use std::env;
-use std::path::Path;
-use std::str::FromStr;
 
 use alloy::consensus::{
     BlobTransactionSidecar, SignableTransaction, TxEip4844, TxEip4844Variant, TxEip4844WithSidecar, TxEnvelope,
@@ -12,20 +9,18 @@ use alloy::eips::eip2930::AccessList;
 use alloy::eips::eip4844::BYTES_PER_BLOB;
 use alloy::network::{Ethereum, TxSigner};
 use alloy::primitives::{bytes, Address, FixedBytes, TxHash, U256, U64};
-use alloy::providers::{Provider, ProviderBuilder, RootProvider};
-use alloy::rpc::client::RpcClient;
+use alloy::providers::{Provider, RootProvider};
 use alloy::signers::wallet::LocalWallet;
 use alloy::transports::http::Http;
 use async_trait::async_trait;
 use c_kzg::{Blob, KzgCommitment, KzgProof, KzgSettings};
 use color_eyre::Result;
-use config::EthereumDaConfig;
 use da_client_interface::{DaClient, DaVerificationStatus};
 use dotenv::dotenv;
+use std::path::Path;
 use mockall::automock;
 use mockall::predicate::*;
 use reqwest::Client;
-use url::Url;
 pub mod config;
 pub struct EthereumDaClient {
     #[allow(dead_code)]

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -4,7 +4,6 @@ use arc_swap::{ArcSwap, Guard};
 use da_client_interface::{DaClient, DaConfig};
 use dotenvy::dotenv;
 use ethereum_da_client::config::EthereumDaConfig;
-use ethereum_da_client::EthereumDaClient;
 use ethereum_settlement_client::EthereumSettlementClient;
 use prover_client_interface::ProverClient;
 use settlement_client_interface::SettlementClient;

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -139,7 +139,7 @@ async fn build_da_client() -> Box<dyn DaClient + Send + Sync> {
     match get_env_var_or_panic("DA_LAYER").as_str() {
         "ethereum" => {
             let config = EthereumDaConfig::new_from_env();
-            Box::new(EthereumDaClient::from(config))
+            Box::new(config.build_da_client().await)
         }
         _ => panic!("Unsupported DA layer"),
     }

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -54,7 +54,7 @@ pub async fn init_config() -> Config {
     // init the queue
     let queue = Box::new(SqsQueue {});
 
-    let da_client = build_da_client();
+    let da_client = build_da_client().await;
 
     let settings_provider = DefaultSettingsProvider {};
     let settlement_client = build_settlement_client(&settings_provider).await;
@@ -135,7 +135,7 @@ pub async fn config_force_init(config: Config) {
 }
 
 /// Builds the DA client based on the environment variable DA_LAYER
-fn build_da_client() -> Box<dyn DaClient + Send + Sync> {
+async fn build_da_client() -> Box<dyn DaClient + Send + Sync> {
     match get_env_var_or_panic("DA_LAYER").as_str() {
         "ethereum" => {
             let config = EthereumDaConfig::new_from_env();

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -138,7 +138,7 @@ async fn build_da_client() -> Box<dyn DaClient + Send + Sync> {
     match get_env_var_or_panic("DA_LAYER").as_str() {
         "ethereum" => {
             let config = EthereumDaConfig::new_from_env();
-            Box::new(config.build_da_client().await)
+            Box::new(config.build_client().await)
         }
         _ => panic!("Unsupported DA layer"),
     }

--- a/crates/utils/src/env_utils.rs
+++ b/crates/utils/src/env_utils.rs
@@ -1,27 +1,19 @@
 use std::env::VarError;
 
-
 pub fn get_env_var(key: &str) -> Result<String, VarError> {
     std::env::var(key)
 }
 
-pub fn get_env_var_optional(key: &str) -> Result<Option<String>,VarError> {
-    match get_env_var(key){
-        Ok(s) => {
-            Ok(Some(s))
-        }
-        Err(VarError::NotPresent) => {
-            Ok(None)
-        }
-        Err(e) => {
-            Err(e)
-        }
+pub fn get_env_var_optional(key: &str) -> Result<Option<String>, VarError> {
+    match get_env_var(key) {
+        Ok(s) => Ok(Some(s)),
+        Err(VarError::NotPresent) => Ok(None),
+        Err(e) => Err(e),
     }
 }
 
 pub fn get_env_car_optional_or_panic(key: &str) -> Option<String> {
     get_env_var_optional(key).unwrap_or_else(|e| panic!("Failed to get env var {}: {}", key, e))
-
 }
 
 pub fn get_env_var_or_panic(key: &str) -> String {

--- a/crates/utils/src/env_utils.rs
+++ b/crates/utils/src/env_utils.rs
@@ -1,7 +1,27 @@
-use color_eyre::Result;
+use std::env::VarError;
 
-pub fn get_env_var(key: &str) -> Result<String> {
-    std::env::var(key).map_err(|e| e.into())
+
+pub fn get_env_var(key: &str) -> Result<String, VarError> {
+    std::env::var(key)
+}
+
+pub fn get_env_var_optional(key: &str) -> Result<Option<String>,VarError> {
+    match get_env_var(key){
+        Ok(s) => {
+            Ok(Some(s))
+        }
+        Err(VarError::NotPresent) => {
+            Ok(None)
+        }
+        Err(e) => {
+            Err(e)
+        }
+    }
+}
+
+pub fn get_env_car_optional_or_panic(key: &str) -> Option<String> {
+    get_env_var_optional(key).unwrap_or_else(|e| panic!("Failed to get env var {}: {}", key, e))
+
 }
 
 pub fn get_env_var_or_panic(key: &str) -> String {

--- a/crates/utils/src/env_utils.rs
+++ b/crates/utils/src/env_utils.rs
@@ -4,6 +4,14 @@ pub fn get_env_var(key: &str) -> Result<String, VarError> {
     std::env::var(key)
 }
 
+pub fn get_env_var_or_panic(key: &str) -> String {
+    get_env_var(key).unwrap_or_else(|e| panic!("Failed to get env var {}: {}", key, e))
+}
+
+pub fn get_env_var_or_default(key: &str, default: &str) -> String {
+    get_env_var(key).unwrap_or(default.to_string())
+}
+
 pub fn get_env_var_optional(key: &str) -> Result<Option<String>, VarError> {
     match get_env_var(key) {
         Ok(s) => Ok(Some(s)),
@@ -14,12 +22,4 @@ pub fn get_env_var_optional(key: &str) -> Result<Option<String>, VarError> {
 
 pub fn get_env_car_optional_or_panic(key: &str) -> Option<String> {
     get_env_var_optional(key).unwrap_or_else(|e| panic!("Failed to get env var {}: {}", key, e))
-}
-
-pub fn get_env_var_or_panic(key: &str) -> String {
-    get_env_var(key).unwrap_or_else(|e| panic!("Failed to get env var {}: {}", key, e))
-}
-
-pub fn get_env_var_or_default(key: &str, default: &str) -> String {
-    get_env_var(key).unwrap_or(default.to_string())
 }


### PR DESCRIPTION
This PR implements `build_client` inside `DaConfig` and removes need for implementing `tryfrom` / `from` completely.

### Problem it solves :
Not all DA clients have a `sync` da client support, this PR allows creating the DA clients `async`.

### Important points to evaluate: 
- declaration of `build_client` on DaConfig.
- `ethereum` DA setup in `build_da_client` inside `crates/orchestrator/src/config.rs`.
- `get_env_var_optional ` : optional env support, if `env` variable is not found, `None` is passed.




